### PR TITLE
README.md missing backslash

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cp config-db.json.example config-db.json
 sequelize db:migrate \
   --migrations-path ./db/migrations \
   --models-path ./db/models \
-  --seeders-path ./db/seeders
+  --seeders-path ./db/seeders \
   --config ./config-db.json
 ```
 


### PR DESCRIPTION
Just added a missing backslash to the db migration command.
Don't know why line 49 is appearing in the diff. I don't think I touched it.